### PR TITLE
Atualização do Encerramento do Teste Vocacional

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -9,68 +9,70 @@ from flask import Blueprint, request, jsonify
 # Blueprint
 main = Blueprint('main', __name__)
 
+# Etapas e perguntas
+etapas = {
+    "autoconhecimento": [
+        "Quais são as atividades que você mais gosta de fazer no dia a dia?",
+        "Quais matérias da escola você mais gosta/gostava?",
+        "Em que tarefas você se destaca?",
+        "Você prefere trabalhar com pessoas, ideias ou máquinas?",
+        "Você gosta de resolver problemas, criar ou seguir instruções?",
+        "Prefere ambientes tranquilos ou agitados?",
+        "O que você faz no tempo livre que te faz perder a noção do tempo?"
+    ],
+    "valores": [
+        "O que é mais importante para você em uma carreira? (ex: estabilidade, propósito, status, ajudar, dinheiro, etc.)",
+        "Onde você gostaria de trabalhar? Escritório? Ar livre? Público?",
+        "Prefere rotina fixa ou flexível?",
+        "Como você define sucesso pessoal/profissional?",
+        "Gosta de trabalhar sozinho ou em equipe?"
+    ],
+    "objetivos": [
+        "Onde você se imagina em 5 a 10 anos?",
+        "Pretende cursar faculdade, técnico ou empreender?",
+        "Aceita cursos longos ou prefere formações práticas?",
+        "Gosta de liderar ou prefere áreas técnicas?",
+        "Quanto espera ganhar em sua profissão ideal?"
+    ],
+    "limitações": [
+        "Alguma limitação financeira, geográfica ou de tempo?",
+        "Tem apoio da família ou depende de si mesmo?",
+        "Trabalha ou pretende trabalhar durante os estudos?",
+        "Já considerou ou descartou alguma carreira? Por quê?"
+    ]
+}
 
-
-# Lista de perguntas
-perguntas = [
-    "Você prefere atividades que exigem criatividade ou que são mais lógicas e organizadas?",
-    "Como você se sente quando precisa trabalhar em grupo? Gosta ou prefere trabalhar sozinho?",
-    # Adicione mais perguntas conforme necessário
-]
-
-# Armazenamento temporário em memória
-chats_perguntas = {}
+# Armazenamento temporário
 chats_contagem_perguntas = {}
 
 def gerar_chat_id():
     return str(uuid.uuid4())
 
+def salvar_mensagem(chat_id, conteudo, tipo="resposta"):
+    db = firestore.client()
+    mensagens_ref = db.collection('chats').document(chat_id).collection('mensagens')
+    mensagens_ref.add({
+        'tipo': tipo,
+        'conteudo': conteudo,
+        'timestamp': firestore.SERVER_TIMESTAMP
+    })
+
 def salvar_resposta_firebase(chat_id, pergunta, resposta):
     db = firestore.client()
+    # Última resposta
     respostas_ref = db.collection('chats').document(chat_id).collection('respostas')
     respostas_ref.add({
         'pergunta': pergunta,
         'resposta': resposta,
         'timestamp': firestore.SERVER_TIMESTAMP
     })
-
-def gerar_prompt_interativo(pergunta, respostas_anteriores, chat_id):
-    prompt_base = (
-        "Você é um assistente vocacional interativo. Seu objetivo é descobrir os interesses e aptidões de um jovem "
-        "para ajudá-lo a identificar áreas profissionais que combinem com seu perfil.\n"
-        "A cada nova pergunta, leve em consideração o que ele já respondeu e formule questões mais específicas.\n"
-        "As perguntas devem ser curtas, claras e diretas, como se fosse uma conversa natural."
-    )
-
-    if isinstance(respostas_anteriores, str):
-        respostas_anteriores = [respostas_anteriores]
-
-    contexto = (
-        f"{prompt_base}\n\n"
-        f"Histórico de respostas do usuário:\n" +
-        "\n".join(respostas_anteriores) +
-        f"\n\nMensagem mais recente do usuário: {pergunta}\n"
-        f"Baseado nesse histórico, responda de forma coerente e em seguida faça uma nova pergunta vocacional."
-    )
-
-    if chat_id in chats_perguntas:
-        perguntas_restantes = [p for p in perguntas if p not in chats_perguntas[chat_id]]
-    else:
-        perguntas_restantes = perguntas.copy()
-
-    if perguntas_restantes:
-        pergunta_aleatoria = random.choice(perguntas_restantes)
-        chats_perguntas.setdefault(chat_id, []).append(pergunta_aleatoria)
-        chats_contagem_perguntas[chat_id] = chats_contagem_perguntas.get(chat_id, 0) + 1
-    else:
-        pergunta_aleatoria = "Você já respondeu todas as perguntas. Podemos sugerir algumas áreas de interesse."
-
-    return contexto, pergunta_aleatoria
+    # Histórico completo
+    salvar_mensagem(chat_id, pergunta, tipo="pergunta")
+    salvar_mensagem(chat_id, resposta, tipo="resposta")
 
 def gerar_areas_respostas(respostas):
     areas = []
     text = " ".join(respostas).lower()
-
     if "trabalho em grupo" in text or "ajudar pessoas" in text:
         areas += ["Psicologia", "Educação", "Serviço Social"]
     if "arte" in text or "criatividade" in text:
@@ -81,8 +83,34 @@ def gerar_areas_respostas(respostas):
         areas += ["Engenharia", "Ciência da Computação", "TI"]
     if "finanças" in text or "números" in text:
         areas += ["Economia", "Administração", "Contabilidade"]
-
     return areas
+
+def gerar_prompt_interativo(pergunta, respostas_anteriores, chat_id):
+    etapa_atual = "autoconhecimento"
+    total_respondidas = len(respostas_anteriores)
+    if total_respondidas >= len(etapas["autoconhecimento"]):
+        etapa_atual = "valores"
+    if total_respondidas >= len(etapas["autoconhecimento"]) + len(etapas["valores"]):
+        etapa_atual = "objetivos"
+    if total_respondidas >= len(etapas["autoconhecimento"]) + len(etapas["valores"]) + len(etapas["objetivos"]):
+        etapa_atual = "limitações"
+
+    perguntas_restantes = etapas[etapa_atual][total_respondidas % len(etapas[etapa_atual]):]
+    if perguntas_restantes:
+        pergunta_aleatoria = perguntas_restantes[0]
+    else:
+        pergunta_aleatoria = "Você já respondeu todas as perguntas. Podemos sugerir algumas áreas de interesse."
+
+    prompt_base = (
+        "Você é um assistente vocacional interativo e simpático. "
+        "A cada nova mensagem, responda com no máximo 3 frases curtas e diretas. "
+        "Evite repetir o que o usuário já disse ou o que você mesmo já comentou. "
+        "Fale como se estivesse conversando com um adolescente no WhatsApp."
+    )
+
+
+    contexto = f"{prompt_base}\n\nHistórico de respostas do usuário:\n" + "\n".join(respostas_anteriores) + f"\n\nMensagem mais recente do usuário: {pergunta}"
+    return contexto, pergunta_aleatoria
 
 @main.route('/api/chat-vocacional', methods=['POST'])
 def chat_vocacional():
@@ -98,16 +126,16 @@ def chat_vocacional():
                 "Explique brevemente o perfil percebido e sugira áreas coerentes.\n\n"
                 "Respostas anteriores:\n" + "\n".join(respostas_anteriores)
             )
-
             resumo = openai.chat.completions.create(
                 model="gpt-3.5-turbo",
-                messages=[
-                    {"role": "system", "content": "Você é um orientador vocacional."},
-                    {"role": "user", "content": resumo_prompt}
-                ],
-                max_tokens=200,
+                messages=[{"role": "system", "content": "Você é um orientador vocacional."},
+                          {"role": "user", "content": resumo_prompt}],
+                max_tokens=80,
                 temperature=0.8
             ).choices[0].message.content
+
+            salvar_mensagem(chat_id, pergunta, tipo="pergunta")
+            salvar_mensagem(chat_id, resumo, tipo="resumo_final")
 
             return jsonify({
                 "resposta": resumo,
@@ -131,22 +159,23 @@ def chat_vocacional():
 
         conteudo = response.choices[0].message.content
 
+        chats_contagem_perguntas[chat_id] = chats_contagem_perguntas.get(chat_id, 0) + 1
         salvar_resposta_firebase(chat_id, pergunta, conteudo)
 
-        if chats_contagem_perguntas.get(chat_id, 0) >= 10:
+        if chats_contagem_perguntas[chat_id] >= 10:
             resumo_prompt = (
                 "Você é um orientador vocacional. Gere um resumo final com base nas respostas anteriores.\n\n"
                 "Respostas anteriores:\n" + "\n".join(respostas_anteriores)
             )
             resumo = openai.chat.completions.create(
                 model="gpt-3.5-turbo",
-                messages=[
-                    {"role": "system", "content": "Você é um orientador vocacional."},
-                    {"role": "user", "content": resumo_prompt}
-                ],
+                messages=[{"role": "system", "content": "Você é um orientador vocacional."},
+                          {"role": "user", "content": resumo_prompt}],
                 max_tokens=200,
                 temperature=0.8
             ).choices[0].message.content
+
+            salvar_mensagem(chat_id, resumo, tipo="resumo_final")
 
             return jsonify({
                 "resposta": resumo,


### PR DESCRIPTION
## ✨ Atualizações no Back-end – Encerramento do Teste Vocacional

### ✅ O que foi feito:
- Implementado controle de encerramento automático do teste vocacional na rota `/api/chat-vocacional`.
- Quando o usuário responde **10 perguntas**, a IA encerra automaticamente o teste e gera um **resumo final**.
- Caso o usuário digite **"encerrar teste"**, o resumo também é gerado manualmente.
- O campo `pergunta_aleatoria` retorna `null` para sinalizar o fim do teste.

### 🧠 Detalhes técnicos:
- O resumo é criado a partir do histórico completo de `respostas_anteriores`.
- O resumo final é salvo na subcoleção `mensagens` com a seguinte estrutura:

  ```json
  {
    "tipo": "resumo_final",
    "conteudo": "...",
    "timestamp": <firestore.SERVER_TIMESTAMP>
  }

### 🧪 Lógica de Encerramento do Teste

Foi adicionada verificação de contagem com:

```python
if chats_contagem_perguntas[chat_id] >= 10:
```
Caso a palavra `"encerrar teste"` seja identificada no campo `mensagem`, o mesmo processo de encerramento também é executado.

### 📌 Impacto
Permite ao front-end identificar que o teste foi finalizado com:
```json
"pergunta_aleatoria": null
```

Com isso, o resultado pode ser salvo separadamente no Firestore na subcoleção `respostas` e exibido ao usuário posteriormente.