### PR TITLE
Chat fica fechado ao encerrar e vem uma mensagem

### DIFF
--- a/frontend/src/pages/chat.jsx
+++ b/frontend/src/pages/chat.jsx
@@ -27,6 +27,7 @@ function Chat() {
   const [loading, setLoading] = useState(false);
   const [respostasAnteriores, setRespostasAnteriores] = useState([]);
   const [isUserLoggedIn, setIsUserLoggedIn] = useState(true); // Verificação de conta
+  const [isTestEnded, setIsTestEnded] = useState(false); // Controle de encerramento do teste
 
   const textareaRef = useRef(null);
   const [textareaHeight, setTextareaHeight] = useState(50); // Define altura inicial do textarea
@@ -54,7 +55,7 @@ function Chat() {
           alert('Erro ao iniciar o chat. Tente novamente.');
         }
       }
-      setIsUserLoggedIn(true); 
+      setIsUserLoggedIn(true);
     });
 
     return () => unsubscribe();
@@ -74,7 +75,13 @@ function Chat() {
         })
       });
 
-      return await response.json();
+      const data = await response.json();
+
+      if (mensagem.toLowerCase() === 'encerrar teste') {
+        setIsTestEnded(true); // Finaliza o teste quando o comando for dado
+      }
+
+      return data;
     } catch (error) {
       console.error('Erro ao enviar para IA:', error);
       return {
@@ -85,7 +92,7 @@ function Chat() {
   };
 
   const handleSend = async () => {
-    if (!input.trim() || !chatId || !isUserLoggedIn) return;
+    if (!input.trim() || !chatId || !isUserLoggedIn || isTestEnded) return;
 
     const userMessage = { sender: 'user', text: input };
     setMessages((prev) => [...prev, userMessage]);
@@ -206,6 +213,12 @@ function Chat() {
             ))}
           </div>
 
+          {isTestEnded && (
+            <div className="alert alert-success text-center mt-3">
+              <strong>Teste encerrado!</strong> Obrigado por participar. Você pode visualizar os resultados agora.
+            </div>
+          )}
+
           <div className="d-flex mt-4">
             <textarea
               ref={textareaRef}
@@ -215,7 +228,7 @@ function Chat() {
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyPress}
               onInput={handleInput} 
-              disabled={!chatId || loading || !isUserLoggedIn}
+              disabled={!chatId || loading || !isUserLoggedIn || isTestEnded} // Desabilita a digitação após o teste ser encerrado
               rows="1" 
               style={{
                 border: '1px solid #ccc',
@@ -231,7 +244,7 @@ function Chat() {
             <button
               className="btn btn-primary rounded-pill px-4"
               onClick={handleSend}
-              disabled={!chatId || loading || !isUserLoggedIn}
+              disabled={!chatId || loading || !isUserLoggedIn || isTestEnded}
             >
               {loading ? 'Enviando...' : 'Enviar'}
             </button>


### PR DESCRIPTION
# PR: Impedir Digitação Após Encerramento do Teste

## Descrição
Este PR implementa uma funcionalidade para impedir que o usuário digite após encerrar o teste vocacional. Quando o usuário digita o comando **"encerrar teste"**, o campo de entrada de mensagens é desabilitado e o teste é finalizado. A mensagem de encerramento é exibida, informando ao usuário que o teste foi concluído.

## Alterações realizadas
- **Adicionado o estado `isTestEnded`**: Controle de encerramento do teste.
- **Atualizado a lógica no `enviarParaIA`**: Quando o usuário digita "encerrar teste", o estado `isTestEnded` é ativado.
- **Desabilitado o campo de entrada de mensagens**: O `textarea` de entrada é desabilitado quando o teste é encerrado.
- **Adicionada uma mensagem de confirmação**: Exibe uma mensagem para o usuário informando que o teste foi encerrado.

## Como testar
1. Inicie uma conversa com o bot no teste vocacional.
2. Envie qualquer mensagem.
3. Digite "encerrar teste" no chat.
4. Verifique se o campo de digitação é desabilitado após o comando.
5. A mensagem de confirmação de encerramento deve ser exibida.

## Impacto
- Melhora a experiência do usuário, evitando a digitação após o término do teste.
- Garante que o teste seja finalizado corretamente com uma interação clara para o usuário.

## Checklist
- [x] Adicionar estado `isTestEnded` para controle de término do teste.
- [x] Atualizar a função `enviarParaIA` para detectar o comando "encerrar teste".
- [x] Desabilitar o campo de entrada após o término do teste.
- [x] Exibir uma mensagem de encerramento para o usuário.
